### PR TITLE
Add a text field for track notes

### DIFF
--- a/components/SheetsControl.js
+++ b/components/SheetsControl.js
@@ -173,10 +173,16 @@ export default class SheetsControl extends React.Component<Props, State> {
   }
 
   handleCreateClick() {
-    const rowValue = val => ({
+    const rowValue = (val, bold) => ({
       userEnteredValue: {
         [typeof val === 'number' ? 'numberValue' : 'stringValue']: val
-      }
+      },
+      textFormatRuns: bold ? [
+        {
+          startIndex: 0,
+          format: { bold: true }
+        }
+      ] : undefined
     })
     const rows = trackIds.map(trackId => [
       tracks[trackId].displayName,
@@ -199,7 +205,7 @@ export default class SheetsControl extends React.Component<Props, State> {
     const data = rows.map((row, i) => ({
       startRow: i,
       rowData: {
-        values: row.map(rowValue)
+        values: row.map((val, j) => rowValue(val, i === 2 || j === 0))
       }
     }))
     gapi.client.sheets.spreadsheets.create({

--- a/components/SheetsControl.js
+++ b/components/SheetsControl.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Milestone, MilestoneMap } from '../constants'
+import type { Milestone, MilestoneMap, NoteMap } from '../constants'
 import { trackIds, tracks } from '../constants'
 
 import React from 'react'
@@ -13,14 +13,16 @@ const CLIENT_ID = '124466069863-0uic3ahingc9bst2oc95h29nvu30lrnu.apps.googleuser
 const DISCOVERY_DOCS = ["https://sheets.googleapis.com/$discovery/rest?version=v4"]
 const SCOPES = "https://www.googleapis.com/auth/spreadsheets"
 
-const RANGE = `B1:b${trackIds.length}`
+const RANGE = `B1:C${trackIds.length+3}`
 
 const DOCS_URL_REGEX = /^https:\/\/docs.google.com\/spreadsheets\/d\/([0-9a-zA-Z_\-]+)/
 
 type Props = {
   name: string,
-  onImport: (milestones: Milestone[]) => void,
-  milestoneByTrack: MilestoneMap
+  title: string,
+  onImport: (name: string, title: string, milestones: Milestone[], notes: string[]) => void,
+  milestoneByTrack: MilestoneMap,
+  notesByTrack: NoteMap
 }
 
 type State = {
@@ -147,14 +149,19 @@ export default class SheetsControl extends React.Component<Props, State> {
     // Get stuff from sheet
     gapi.client.sheets.spreadsheets.values.get({
       spreadsheetId: this.state.sheetId,
-      range: RANGE
+      range: RANGE,
+      majorDimension: 'COLUMNS'
     }).then(response => {
       console.log('imported sheet')
       const range = response.result
       if (range.values.length > 0) {
-        const milestones = range.values.map(val => parseInt(val[0]))
-        milestones.forEach(milestone => console.log(milestone))
-        this.props.onImport(milestones)
+        // Special-case the first two rows
+        const name = range.values[0][0]
+        const title = range.values[1][0]
+        // Skip the third as they're just constant headers
+        const milestones = range.values[0].slice(3).map(val => parseInt(val[0]))
+        const notes = range.values[1].slice(3)
+        this.props.onImport(name, title, milestones, notes)
       } else {
         console.log('no values found')
       }
@@ -166,22 +173,33 @@ export default class SheetsControl extends React.Component<Props, State> {
   }
 
   handleCreateClick() {
-    const rows = trackIds.map(trackId => [tracks[trackId].displayName, this.props.milestoneByTrack[trackId]])
+    const rowValue = val => ({
+      userEnteredValue: {
+        [typeof val === 'number' ? 'numberValue' : 'stringValue']: val
+      }
+    })
+    const rows = trackIds.map(trackId => [
+      tracks[trackId].displayName,
+      this.props.milestoneByTrack[trackId],
+      this.props.notesByTrack[trackId]
+    ])
+    rows.unshift([
+      'Track',
+      'Milestone',
+      'Notes'
+    ])
+    rows.unshift([
+      'Title',
+      this.props.title
+    ])
+    rows.unshift([
+      'Name',
+      this.props.name
+    ])
     const data = rows.map((row, i) => ({
       startRow: i,
       rowData: {
-        values: [
-          {
-            userEnteredValue: {
-              stringValue: row[0]
-            }
-          },
-          {
-            userEnteredValue: {
-              numberValue: row[1]
-            }
-          }
-        ]
+        values: row.map(rowValue)
       }
     }))
     gapi.client.sheets.spreadsheets.create({
@@ -195,14 +213,22 @@ export default class SheetsControl extends React.Component<Props, State> {
   }
 
   handleSaveClick() {
-    const values = trackIds.map(trackId => this.props.milestoneByTrack[trackId])
+    const headers = [
+      [this.props.name],
+      [this.props.title],
+      ['Milestone', 'Notes']
+    ]
+    const values = trackIds.map(trackId => [
+      this.props.milestoneByTrack[trackId],
+      this.props.notesByTrack[trackId]
+    ])
     gapi.client.sheets.spreadsheets.values.update({
       spreadsheetId: this.state.sheetId,
       range: RANGE,
       valueInputOption: 'USER_ENTERED',
       resource: {
-        majorDimension: 'COLUMNS',
-        values: [ values ]
+        majorDimension: 'ROWS',
+        values: headers.concat(values)
       }
     }).then(() => {
       console.log('saved')

--- a/components/SnowflakeApp.js
+++ b/components/SnowflakeApp.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { Milestone, MilestoneMap, TrackId } from '../constants'
+import type { Milestone, MilestoneMap, NoteMap, TrackId } from '../constants'
 import { eligibleTitles, milestoneToPoints, milestones, trackIds } from '../constants'
 
 import KeyboardListener from '../components/KeyboardListener'
@@ -15,6 +15,7 @@ import TrackSelector from '../components/TrackSelector'
 import Wordmark from '../components/Wordmark'
 
 type SnowflakeAppState = {
+  notesByTrack: NoteMap,
   milestoneByTrack: MilestoneMap,
   name: string,
   title: string,
@@ -69,6 +70,7 @@ const emptyState = (): SnowflakeAppState => {
       'RECRUITING': 0,
       'COMMUNITY': 0
     },
+    notesByTrack: {},
     focusedTrackId: 'MOBILE'
   }
 }
@@ -95,6 +97,7 @@ const defaultState = (): SnowflakeAppState => {
       'RECRUITING': 3,
       'COMMUNITY': 0
     },
+    notesByTrack: {},
     focusedTrackId: 'MOBILE'
   }
 }
@@ -174,8 +177,10 @@ class SnowflakeApp extends React.Component<Props, SnowflakeAppState> {
                   />
               <SheetsControl
                   name={this.state.name}
+                  title={this.state.title}
                   onImport={this.handleSheetsImport.bind(this)}
-                  milestoneByTrack={this.state.milestoneByTrack} />
+                  milestoneByTrack={this.state.milestoneByTrack}
+                  notesByTrack={this.state.notesByTrack} />
               <TitleSelector
                   milestoneByTrack={this.state.milestoneByTrack}
                   currentTitle={this.state.title}
@@ -202,8 +207,10 @@ class SnowflakeApp extends React.Component<Props, SnowflakeAppState> {
             decreaseFocusedMilestoneFn={this.shiftFocusedTrackMilestoneByDelta.bind(this, -1)} />
         <Track
             milestoneByTrack={this.state.milestoneByTrack}
+            notesByTrack={this.state.notesByTrack}
             trackId={this.state.focusedTrackId}
-            handleTrackMilestoneChangeFn={(track, milestone) => this.handleTrackMilestoneChange(track, milestone)} />
+            handleTrackMilestoneChangeFn={(track, milestone) => this.handleTrackMilestoneChange(track, milestone)}
+            handleTrackNoteChangeFn={(track, note) => this.handleTrackNoteChange(track, note)} />
         <div style={{display: 'flex', paddingBottom: '20px'}}>
           <div style={{flex: 1}}>
             <a href="#" onClick={() => this.setState(emptyState())}>Reset</a>
@@ -219,12 +226,16 @@ class SnowflakeApp extends React.Component<Props, SnowflakeAppState> {
     )
   }
 
-  handleSheetsImport(milestones: Milestone[]) {
+  handleSheetsImport(name: string, title: string, milestones: Milestone[], notes: string[]) {
     const milestoneByTrack = {}
     milestones.forEach((milestone, i) => {
       milestoneByTrack[trackIds[i]] = milestone
     })
-    this.setState({ milestoneByTrack })
+    const notesByTrack = {}
+    notes.forEach((note, i) => {
+      notesByTrack[trackIds[i]] = note
+    })
+    this.setState({ name, title, milestoneByTrack, notesByTrack })
   }
 
   handleTrackMilestoneChange(trackId: TrackId, milestone: Milestone) {
@@ -235,6 +246,13 @@ class SnowflakeApp extends React.Component<Props, SnowflakeAppState> {
     const title = titles.indexOf(this.state.title) === -1 ? titles[0] : this.state.title
 
     this.setState({ milestoneByTrack, focusedTrackId: trackId, title })
+  }
+
+  handleTrackNoteChange(trackId: TrackId, note: string) {
+    const notesByTrack = Object.assign({}, this.state.notesByTrack)
+    notesByTrack[trackId] = note
+
+    this.setState({ notesByTrack })
   }
 
   shiftFocusedTrack(delta: number) {

--- a/components/Track.js
+++ b/components/Track.js
@@ -2,12 +2,14 @@
 
 import { tracks, milestones, categoryColorScale } from '../constants'
 import React from 'react'
-import type { MilestoneMap, TrackId, Milestone } from '../constants'
+import type { MilestoneMap, NoteMap, TrackId, Milestone } from '../constants'
 
 type Props = {
   milestoneByTrack: MilestoneMap,
+  notesByTrack: NoteMap,
   trackId: TrackId,
-  handleTrackMilestoneChangeFn: (TrackId, Milestone) => void
+  handleTrackMilestoneChangeFn: (TrackId, Milestone) => void,
+  handleTrackNoteChangeFn: (TrackId, string) => void
 }
 
 class Track extends React.Component<Props> {
@@ -15,6 +17,7 @@ class Track extends React.Component<Props> {
     const track = tracks[this.props.trackId]
     const currentMilestoneId = this.props.milestoneByTrack[this.props.trackId]
     const currentMilestone = track.milestones[currentMilestoneId - 1]
+    const currentNotes = this.props.notesByTrack[this.props.trackId] || ''
     return (
       <div className="track">
         <style jsx>{`
@@ -83,6 +86,13 @@ class Track extends React.Component<Props> {
               </ul>
             </div>
           ) : null}
+        </div>
+        <div style={{display: 'flex'}}>
+          <textarea
+            style={{flex: 1}}
+            rows='10'
+            value={currentNotes}
+            onChange={e => this.props.handleTrackNoteChangeFn(this.props.trackId, e.currentTarget.value)} />
         </div>
       </div>
     )

--- a/constants.js
+++ b/constants.js
@@ -23,6 +23,10 @@ type Tracks = {|
 export type TrackId = $Keys<Tracks>;
 export type Milestone = 0 | 1 | 2 | 3 | 4 | 5;
 
+export type NoteMap = {
+  [TrackId]: ?string
+}
+
 export type MilestoneMap = {
   [TrackId]: Milestone
 };


### PR DESCRIPTION
![Note](https://media.giphy.com/media/9PMC8BD8b2AaA/giphy.gif)

This adds a text field for taking notes on individual tracks. These notes are saved when the snowflake is exported to a Google Sheet, but not in the URL.

Somewhat unrelated, but this also saves the person's name and title in the sheet, so now the sheet should represent the snowflake completely. In the second commit I also improved the sheet formatting by making certain cells bold. It's a bit hacky, I admit.

The text field at the bottom:

![image](https://user-images.githubusercontent.com/369904/47762459-ae232c00-dd21-11e8-9e9c-f16bff153ec7.png)

The resulting spreadsheet:

![image](https://user-images.githubusercontent.com/369904/47762503-da3ead00-dd21-11e8-967d-08c6b0e6ca79.png)
